### PR TITLE
Fix buildah running within a container

### DIFF
--- a/sync-latest-container-base-image.sh
+++ b/sync-latest-container-base-image.sh
@@ -3,7 +3,7 @@
 export STORAGE_DRIVER=vfs
 
 image_repo=quay.io/fedoraci/fedora
-arches=(aarch64 ppc64le x86_64 s390x)
+arches=(aarch64 ppc64le x86_64) # s390x disabled
 
 eln_build_name=$(koji -q latest-build --type=image eln-updates-candidate Fedora-Container-Base | awk '{print $1}')
 if [[ -n ${eln_build_name} ]]; then
@@ -24,7 +24,7 @@ if [[ -n ${eln_build_name} ]]; then
     done
 
     # Create and upload multi-arch manifest
-    buildah rmi "$image_repo:eln"  # jic the manifest already exists
+    buildah rmi "$image_repo:eln" || true  # jic the manifest already exists
     buildah manifest create "$image_repo:eln" "${arches[@]/#/docker://$image_repo:eln-}"
     buildah manifest push --creds="$USERNAME:$PASSWORD" "$image_repo:eln" "docker://$image_repo:eln" --all
 

--- a/sync-latest-container-base-image.sh
+++ b/sync-latest-container-base-image.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+export STORAGE_DRIVER=vfs
+
 image_repo=quay.io/fedoraci/fedora
 arches=(aarch64 ppc64le x86_64 s390x)
 

--- a/sync-latest-container-base-image.sh
+++ b/sync-latest-container-base-image.sh
@@ -5,6 +5,12 @@ export STORAGE_DRIVER=vfs
 image_repo=quay.io/fedoraci/fedora
 arches=(aarch64 ppc64le x86_64) # s390x disabled
 
+if [ -v CHANGE_ID ]; then
+    tag_suffix=-pr-${CHANGE_ID}
+else
+    tag_suffix=''
+fi
+
 eln_build_name=$(koji -q latest-build --type=image eln-updates-candidate Fedora-Container-Base | awk '{print $1}')
 if [[ -n ${eln_build_name} ]]; then
     # Download the image
@@ -17,7 +23,7 @@ if [[ -n ${eln_build_name} ]]; then
 	image="${eln_build_name}.${arch}.tar.xz"
 	if [[ -f "$image" ]]; then
             xz -d "${image}"
-            skopeo copy --dest-creds="$USERNAME:$PASSWORD" docker-archive:${eln_build_name}.${arch}.tar "docker://$image_repo:eln-${arch}"
+            skopeo copy --dest-creds="$USERNAME:$PASSWORD" docker-archive:${eln_build_name}.${arch}.tar "docker://$image_repo:eln${tag_suffix}-${arch}"
 	else
 	    echo "WARNING: Image ${eln_build_name} for ${arch} not found"
 	fi
@@ -25,8 +31,8 @@ if [[ -n ${eln_build_name} ]]; then
 
     # Create and upload multi-arch manifest
     buildah rmi "$image_repo:eln" || true  # jic the manifest already exists
-    buildah manifest create "$image_repo:eln" "${arches[@]/#/docker://$image_repo:eln-}"
-    buildah manifest push --creds="$USERNAME:$PASSWORD" "$image_repo:eln" "docker://$image_repo:eln" --all
+    buildah manifest create "$image_repo:eln${tag_suffix}" "${arches[@]/#/docker://$image_repo:eln${tag_suffix}-}"
+    buildah manifest push --creds="$USERNAME:$PASSWORD" "$image_repo:eln${tag_suffix}" "docker://$image_repo:eln${tag_suffix}" --all
 
     popd &> /dev/null
 


### PR DESCRIPTION
This should fix the following error message in the Jenkins jobs:
    'overlay' is not supported over overlayfs, a mount_program is
    required: backing file system is unsupported for this graph driver

Signed-off-by: Michael Hofmann <mhofmann@redhat.com>