### PR TITLE
Update ELN base container name

### DIFF
--- a/sync-latest-container-base-image.sh
+++ b/sync-latest-container-base-image.sh
@@ -11,7 +11,7 @@ else
     tag_suffix=''
 fi
 
-eln_build_name=$(koji -q latest-build --type=image eln-updates-candidate Fedora-Container-Base | awk '{print $1}')
+eln_build_name=$(koji -q latest-build --type=image eln-updates-candidate Fedora-ELN-Container-Base-Generic | awk '{print $1}')
 if [[ -n ${eln_build_name} ]]; then
     # Download the image
     work_dir=$(mktemp -d)


### PR DESCRIPTION
Due to the switch to Kiwi for image generation, the built image name has changed to Fedora-ELN-Container-Base-Generic.